### PR TITLE
fix: regenerate lockfile so frozen install matches package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   default:
-    vite:
-      specifier: npm:@voidzero-dev/vite-plus-core@0.2.9
-      version: 0.2.9
     vite-plus:
       specifier: 0.2.9
       version: 0.2.9
@@ -36,7 +33,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: 'catalog:'
+        specifier: npm:@voidzero-dev/vite-plus-core@0.2.9
         version: '@voidzero-dev/vite-plus-core@0.2.9(@types/node@26.2.0)(typescript@7.0.2)(yaml@2.9.0)'
       vite-plugin-glsl:
         specifier: ^1.6.1


### PR DESCRIPTION
Fixes the failing deploy on master.

The dependency bump in #20 was written by pnpm 11.11.0, which recorded the vite importer specifier as `catalog:` and added a redundant `vite` catalog entry. Pinning `packageManager` to 11.21.0 in the same PR left a lockfile whose shape the newer resolver rejects.

`pnpm install --frozen-lockfile` failed in CI with `ERR_PNPM_OUTDATED_LOCKFILE` while passing locally, because an existing `node_modules` lets the install short-circuit before verifying specifiers.

Regenerated under 11.21.0, restoring the resolved-override specifier the lockfile carried before the bump. Verified from a clean clone with no `node_modules`: frozen install, `pnpm check`, `typecheck` and `build` all pass.